### PR TITLE
Migration validation fix

### DIFF
--- a/system/Database/MigrationRunner.php
+++ b/system/Database/MigrationRunner.php
@@ -198,6 +198,8 @@ class MigrationRunner
 		{
 			return true;
 		}
+		
+		$previous = false;
 
 		// Validate all available migrations, and run the ones within our target range
 		foreach ($migrations as $number => $file)


### PR DESCRIPTION
The $previous variable isn't set, so the foreach loops fails on first time when checking its value.